### PR TITLE
Cache generation admin command

### DIFF
--- a/Commands.py
+++ b/Commands.py
@@ -285,7 +285,7 @@ def admin(req, arg):
 				arg = arg[1:]
 				whois_list = []
 				with Global.account_lock:
-					if arg[0] == "*":
+					if len(arg) == 0 or arg[0] == "*":
 						for channel in Global.account_cache:
 							for nick in Global.account_cache[channel]:
 								whois_list.append(nick)

--- a/Commands.py
+++ b/Commands.py
@@ -281,6 +281,22 @@ def admin(req, arg):
 		elif command == "part":
 			Irc.instance_send(req.instance, ("PART", arg[0]), priority = 0.1)
 		elif command == "caches":
+			if len(arg) > 0 and arg[0] == "generate":
+				arg = arg[1:]
+				whois_list = []
+				with Global.account_lock:
+					if arg[0] == "*":
+						for channel in Global.account_cache:
+							for nick in Global.account_cache[channel]:
+								whois_list.append(nick)
+					else:
+						for item in arg:
+							if item[0] == "#" and item in Global.account_cache:
+								for nick in Global.account_cache[item]:
+									whois_list.append(nick)
+							else:
+								whois_list.append(item)
+				Irc.account_names(whois_list)
 			acsize = 0
 			accached = 0
 			with Global.account_lock:


### PR DESCRIPTION
Add an optionnal argument to « caches » to mass WHOIS users not in caches. Useful for the rain command when the bot has not his cache fully populated.